### PR TITLE
fix: re-apply theme class after View Transitions page swap

### DIFF
--- a/src/layouts/app/BaseHead.astro
+++ b/src/layouts/app/BaseHead.astro
@@ -148,8 +148,17 @@ const { title, description = SITE_DESCRIPTION } = Astro.props;
             attributeFilter: ["class"],
         });
 
-        // Re-apply theme eagerly after each View Transitions page swap,
-        // before ModeWatcher (client:load) has a chance to initialize.
+        // Astro View Transitions replaces the entire <html> element with the
+        // server-rendered version (which has no dark class). Stamp the correct
+        // class onto the *incoming* document before the swap so there is never
+        // a frame where the wrong theme is visible.
+        document.addEventListener("astro:before-swap", (e) => {
+            const isDark = getThemePreference() === "dark";
+            e.newDocument.documentElement.classList[isDark ? "add" : "remove"]("dark");
+        });
+
+        // Belt-and-suspenders: also re-apply after the swap in case anything
+        // else (e.g. ModeWatcher re-initializing) removes the class.
         document.addEventListener("astro:after-swap", applyTheme);
     }
 </script>

--- a/src/layouts/app/BaseHead.astro
+++ b/src/layouts/app/BaseHead.astro
@@ -130,8 +130,13 @@ const { title, description = SITE_DESCRIPTION } = Astro.props;
         }
         return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     };
-    const isDark = getThemePreference() === "dark";
-    document.documentElement.classList[isDark ? "add" : "remove"]("dark");
+
+    function applyTheme() {
+        const isDark = getThemePreference() === "dark";
+        document.documentElement.classList[isDark ? "add" : "remove"]("dark");
+    }
+
+    applyTheme();
 
     if (isBrowser) {
         const observer = new MutationObserver(() => {
@@ -142,5 +147,9 @@ const { title, description = SITE_DESCRIPTION } = Astro.props;
             attributes: true,
             attributeFilter: ["class"],
         });
+
+        // Re-apply theme eagerly after each View Transitions page swap,
+        // before ModeWatcher (client:load) has a chance to initialize.
+        document.addEventListener("astro:after-swap", applyTheme);
     }
 </script>


### PR DESCRIPTION
## Summary

- `is:inline` scripts only execute on initial hard page load, not on client-side navigations via Astro's `ClientRouter`
- Astro's View Transitions replaces the entire `<html>` element with the server-rendered version (which has no `dark` class), causing a flash of the wrong theme on every navigation
- Fix: listen to `astro:before-swap` and stamp the correct class onto `event.newDocument.documentElement` before the swap — so the incoming `<html>` already has the right theme when it replaces the current one
- `astro:after-swap` is kept as a secondary guard in case `ModeWatcher` re-initialization removes the class after the swap

## Test plan

- [ ] Navigate between pages in dark mode — no light mode flash should be visible
- [ ] Navigate between pages in light mode — no dark mode flash should be visible
- [ ] Hard refresh still applies correct theme immediately
- [ ] Toggling theme via the appearance switch still persists across navigations