### PR TITLE
feat: add CSP and security headers via middleware

### DIFF
--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -1,0 +1,35 @@
+const cspDirectives: Record<string, string> = {
+    "default-src": "'self'",
+    // data: required at runtime — Astro's ClientRouter loads data: URIs during view transitions
+    "script-src": "'self' 'unsafe-inline' data:",
+    // unsafe-inline required for Svelte inline styles and Tailwind CSS
+    "style-src": "'self' 'unsafe-inline'",
+    // data: for inline SVG images
+    "img-src": "'self' data:",
+    // fonts are self-hosted
+    "font-src": "'self'",
+    // no client-side API calls to external services
+    "connect-src": "'self'",
+    "frame-src": "'none'",
+    "frame-ancestors": "'none'",
+    "object-src": "'none'",
+    "base-uri": "'self'",
+    "form-action": "'self'",
+    "upgrade-insecure-requests": "",
+};
+
+const cspValue = Object.entries(cspDirectives)
+    .map(([key, value]) => (value ? `${key} ${value}` : key))
+    .join("; ");
+
+export function addSecurityHeaders(headers: Headers): void {
+    headers.set("Content-Security-Policy", cspValue);
+    headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    headers.set("X-Frame-Options", "DENY");
+    headers.set("X-Content-Type-Options", "nosniff");
+    headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+    headers.set(
+        "Permissions-Policy",
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()",
+    );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,8 @@
+import { defineMiddleware } from "astro:middleware";
+import { addSecurityHeaders } from "./lib/securityHeaders";
+
+export const onRequest = defineMiddleware(async (_context, next) => {
+    const response = await next();
+    addSecurityHeaders(response.headers);
+    return response;
+});


### PR DESCRIPTION
## Summary
- Add all standard security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) via Astro middleware
- CSP directives are tailored to this site: self-hosted fonts, server-side-only Spotify API calls, and `'unsafe-inline'` for Astro's `ClientRouter` view transitions and Svelte inline styles

## Test plan
- [ ] Run `npm run build` — builds without errors
- [ ] Run `npm run preview` and check response headers in DevTools Network tab — all 6 headers present
- [ ] Browse the site and verify no CSP violation errors in console
- [ ] After deployment, verify with https://securityheaders.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)