### PR TITLE
feat: Spotify caching, time blur reveal, link styling, CSP fixes

### DIFF
--- a/src/components/AboutMe.astro
+++ b/src/components/AboutMe.astro
@@ -9,7 +9,7 @@
         <br /><br />
         I got a Bachelor{"'"}s Degree in Business Administration and Information Systems from{" "}
         <a
-            class="text-cbs hover:underline underline-offset-2"
+            class="text-cbs underline decoration-cbs/30 underline-offset-2 hover:decoration-cbs transition-colors duration-200"
             href="https://www.cbs.dk/uddannelse/bachelor/hait-erhvervsoekonomi-informationsteknologi"
             target="_blank"
             rel="noopener noreferrer"

--- a/src/components/AvatarCard.astro
+++ b/src/components/AvatarCard.astro
@@ -18,7 +18,7 @@ import avatarImage from "../assets/avatar.jpg";
             <br />
             Creator and maintainer of the{" "}<span class="text-Discord">Discord</span> bot{" "}
             <a
-                class="dark:text-yellow-300 text-yellow-600 hover:underline underline-offset-2"
+                class="dark:text-yellow-300 text-yellow-600 underline decoration-yellow-600/30 dark:decoration-yellow-300/30 underline-offset-2 hover:decoration-yellow-600 dark:hover:decoration-yellow-300 transition-colors duration-200"
                 href="https://bentobot.xyz"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -29,7 +29,7 @@ import avatarImage from "../assets/avatar.jpg";
             Currently studying a Master{"'"}s Degree in Business Administration and Information
             Systems at{" "}
             <a
-                class="text-cbs hover:underline underline-offset-2"
+                class="text-cbs underline decoration-cbs/30 underline-offset-2 hover:decoration-cbs transition-colors duration-200"
                 href="https://www.cbs.dk/en/study/graduate/msc-in-business-administration-and-information-systems"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/components/spotify/Spotify.astro
+++ b/src/components/spotify/Spotify.astro
@@ -5,11 +5,14 @@ import SpotifyIcon from "../icons/SpotifyIcon.astro";
 import { getNowPlaying } from "../../lib/spotify";
 import { env } from "cloudflare:workers";
 
-const data = await getNowPlaying({
-    clientId: env.SPOTIFY_CLIENT_ID,
-    clientSecret: env.SPOTIFY_CLIENT_SECRET,
-    refreshToken: env.SPOTIFY_REFRESH_TOKEN,
-});
+const data = await getNowPlaying(
+    {
+        clientId: env.SPOTIFY_CLIENT_ID,
+        clientSecret: env.SPOTIFY_CLIENT_SECRET,
+        refreshToken: env.SPOTIFY_REFRESH_TOKEN,
+    },
+    env.SESSION
+);
 const loading = !data || typeof data.isPlaying === "undefined";
 ---
 

--- a/src/components/time/Time.svelte
+++ b/src/components/time/Time.svelte
@@ -2,7 +2,8 @@
     import { onMount, onDestroy } from "svelte";
 
     let time = "";
-    let intervalId: ReturnType<typeof setInterval>;
+    let revealed = false;
+    let timeoutId: ReturnType<typeof setTimeout>;
 
     const updateTime = () => {
         const formatter = new Intl.DateTimeFormat("en-DK", {
@@ -14,14 +15,55 @@
         time = formatter.format(new Date());
     };
 
+    const scheduleNextUpdate = () => {
+        const now = new Date();
+        const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+        timeoutId = setTimeout(() => {
+            updateTime();
+            scheduleNextUpdate();
+        }, msUntilNextMinute);
+    };
+
+    const reveal = () => {
+        revealed = true;
+        scheduleNextUpdate();
+    };
+
     onMount(() => {
         updateTime();
-        intervalId = setInterval(updateTime, 60000);
     });
 
     onDestroy(() => {
-        clearInterval(intervalId);
+        clearTimeout(timeoutId);
     });
 </script>
 
-<span class="text-black dark:text-white font-medium">{time}</span>
+<span
+    class="time-display font-medium {revealed
+        ? 'time-revealed text-black dark:text-white'
+        : 'time-blurred text-zinc-400 dark:text-zinc-500'}"
+    class:interactive={!revealed}
+    on:click={() => !revealed && reveal()}
+    on:keydown={(e) => !revealed && e.key === "Enter" && reveal()}
+    role={revealed ? undefined : "button"}
+    tabindex={revealed ? undefined : 0}
+    title={revealed ? undefined : "Click to reveal the time"}>{time}</span
+>
+
+<style>
+    .time-blurred {
+        filter: blur(8px);
+        cursor: pointer;
+        user-select: none;
+        transition: filter 0.4s ease;
+    }
+
+    .time-blurred:hover {
+        filter: blur(4px);
+    }
+
+    .time-revealed {
+        filter: blur(0);
+        transition: filter 0.6s ease-out;
+    }
+</style>

--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -10,8 +10,10 @@ const cspDirectives: Record<string, string> = {
     "font-src": "'self'",
     // no client-side API calls to external services
     "connect-src": "'self'",
-    "frame-src": "'none'",
-    "frame-ancestors": "'none'",
+    // 'self' required — Astro's ClientRouter uses iframes for view transitions
+    "frame-src": "'self'",
+    // 'self' required — Astro's ClientRouter frames the current origin during navigation
+    "frame-ancestors": "'self'",
     "object-src": "'none'",
     "base-uri": "'self'",
     "form-action": "'self'",
@@ -25,7 +27,7 @@ const cspValue = Object.entries(cspDirectives)
 export function addSecurityHeaders(headers: Headers): void {
     headers.set("Content-Security-Policy", cspValue);
     headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
-    headers.set("X-Frame-Options", "DENY");
+    headers.set("X-Frame-Options", "SAMEORIGIN");
     headers.set("X-Content-Type-Options", "nosniff");
     headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
     headers.set(

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -4,6 +4,14 @@ const TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token";
 let cachedAccessToken: string | null = null;
 let tokenExpiryTime: number | null = null;
 
+let cachedNowPlaying: NowPlayingSong | null = null;
+let nowPlayingCacheExpiry: number | null = null;
+const NOW_PLAYING_TTL_MS = 30_000;
+const KV_TIMEOUT_MS = 500;
+
+const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T | null> =>
+    Promise.race([promise, new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))]);
+
 interface SpotifyCredentials {
     clientId: string;
     clientSecret: string;
@@ -62,7 +70,32 @@ const EMPTY_RESPONSE: NowPlayingSong = {
     title: "",
 };
 
-export const getNowPlaying = async (credentials: SpotifyCredentials): Promise<NowPlayingSong> => {
+export const getNowPlaying = async (
+    credentials: SpotifyCredentials,
+    kv?: KVNamespace
+): Promise<NowPlayingSong> => {
+    const currentTime = Date.now();
+
+    if (cachedNowPlaying && nowPlayingCacheExpiry && currentTime < nowPlayingCacheExpiry) {
+        return cachedNowPlaying;
+    }
+
+    if (kv) {
+        try {
+            const kvCached = await withTimeout(
+                kv.get<NowPlayingSong>("spotify:now-playing", "json"),
+                KV_TIMEOUT_MS
+            );
+            if (kvCached) {
+                cachedNowPlaying = kvCached;
+                nowPlayingCacheExpiry = currentTime + NOW_PLAYING_TTL_MS;
+                return kvCached;
+            }
+        } catch {
+            // KV read failed, fall through to API
+        }
+    }
+
     try {
         const accessToken = await getAccessToken(credentials);
 
@@ -84,7 +117,7 @@ export const getNowPlaying = async (credentials: SpotifyCredentials): Promise<No
         const song = await response.json();
         if (!song?.item) return EMPTY_RESPONSE;
 
-        return {
+        const result: NowPlayingSong = {
             album: song.item.album?.name ?? "",
             albumImageUrl: song.item.album?.images?.[0]?.url ?? "",
             artist: song.item.artists?.map((a: { name: string }) => a.name).join(", ") ?? "",
@@ -92,6 +125,22 @@ export const getNowPlaying = async (credentials: SpotifyCredentials): Promise<No
             songUrl: song.item.external_urls?.spotify ?? "",
             title: song.item.name ?? "",
         };
+
+        cachedNowPlaying = result;
+        nowPlayingCacheExpiry = currentTime + NOW_PLAYING_TTL_MS;
+
+        if (kv) {
+            try {
+                await withTimeout(
+                    kv.put("spotify:now-playing", JSON.stringify(result), { expirationTtl: 30 }),
+                    KV_TIMEOUT_MS
+                );
+            } catch {
+                // KV write failed, not critical
+            }
+        }
+
+        return result;
     } catch (error) {
         console.error("Error fetching now playing data:", error);
         return EMPTY_RESPONSE;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -64,7 +64,7 @@
 
     html {
         /* Reserve space for the scrollbar to prevent layout shift between pages */
-        scrollbar-gutter: stable both-edges;
+        scrollbar-gutter: stable;
         font-family:
             "Inter",
             system-ui,


### PR DESCRIPTION
## Summary
- **Spotify caching**: Added dual-layer caching (in-memory 30s TTL + Cloudflare KV) to `getNowPlaying()` so the Spotify API is no longer hit on every page load. KV operations include a 500ms timeout to prevent hanging in dev.
- **Time blur reveal**: Time in footer now renders blurred initially — hover reduces blur, click fully reveals with a smooth animation. Uses recursive `setTimeout` aligned to minute boundaries for accurate updates.
- **Link styling**: Links on home and about pages now have persistent underlines at 30% opacity that transition to full opacity on hover, improving clickability affordance.
- **CSP fixes**: Updated `frame-src` and `frame-ancestors` from `'none'` to `'self'` and `X-Frame-Options` to `SAMEORIGIN` to unblock Astro's ClientRouter navigation.
- **Scrollbar gutter**: Changed `scrollbar-gutter: stable both-edges` to `stable` to fix loading indicator not spanning full width.

## Test plan
- [x] Navigate between pages — loading indicator spans full width, no CSP errors in console
- [x] Check Spotify footer: displays now playing or "Not Playing", subsequent page loads use cached data
- [x] Hover over blurred time in footer — blur reduces; click to reveal with smooth animation
- [x] Verify links on home/about pages show subtle persistent underlines
- [x] Run `npm run build && npm run preview` for Wrangler local test

🤖 Generated with [Claude Code](https://claude.com/claude-code)