### PR TITLE
Handle Spotify refresh token expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ Credits to [Lee Robinson](https://github.com/leerob/leerob.io) for design inspir
 2. `npm install`
 3. `npm run dev`
 
+## Spotify authorization
+
+The footer reads the site owner's currently playing track with Spotify's Authorization Code
+flow. Add this exact redirect URI to the app in the Spotify Developer Dashboard:
+
+```text
+http://127.0.0.1:8888/callback
+```
+
+Spotify refresh tokens expire six months after authorization. To authorize the account and
+replace both the local token and the production Cloudflare secret, run:
+
+```bash
+npm run spotify:authorize
+```
+
+The command opens Spotify sign-in, saves the resulting refresh token to the ignored `.env`, and
+publishes it to Cloudflare through Wrangler. It never prints the token. Use `--local-only` to skip
+Cloudflare publication, or `--publish-only` to retry publishing the token already stored in
+`.env`.
+
+If production receives Spotify's `invalid_grant` response, it stops retrying that token, renders
+the normal “Not Playing” footer state, and writes a `spotify_reauthorization_required` event to
+the Worker logs. Run the command above to restore the integration.
+
 ## Contributing
 
 If you want to contribute, feel free to open an issue or a pull request. I am always open to suggestions and improvements.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,16 @@ export default [
     eslintJs.configs.recommended,
     ...tseslint.configs.recommended,
 
+    // Node.js maintenance scripts
+    {
+        files: ["scripts/**/*.mjs"],
+        languageOptions: {
+            globals: {
+                ...globals.node,
+            },
+        },
+    },
+
     // Configuration for Svelte files with TypeScript
     ...sveltePlugin.configs.recommended,
     {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "build": "astro build",
         "preview": "astro build && wrangler dev",
         "deploy": "astro build && wrangler deploy",
+        "spotify:authorize": "node --env-file-if-exists=.env scripts/spotify-authorize.mjs",
         "lint": "eslint . --ignore-pattern worker-configuration.d.ts",
         "lint:fix": "eslint . --fix --ignore-pattern worker-configuration.d.ts",
         "format": "prettier --write .",

--- a/scripts/__tests__/spotify-authorize.test.ts
+++ b/scripts/__tests__/spotify-authorize.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    buildAuthorizationUrl,
+    exchangeAuthorizationCode,
+    publishRefreshToken,
+    upsertEnvValue,
+    validateCallbackParameters,
+    verifyAccessToken,
+} from "../spotify-authorize.mjs";
+
+describe("Spotify authorization helper", () => {
+    it("builds a forced authorization-code flow with the required scope and state", () => {
+        const url = buildAuthorizationUrl({ clientId: "client-id", state: "secure-state" });
+
+        expect(url.origin + url.pathname).toBe("https://accounts.spotify.com/authorize");
+        expect(Object.fromEntries(url.searchParams)).toEqual({
+            client_id: "client-id",
+            redirect_uri: "http://127.0.0.1:8888/callback",
+            response_type: "code",
+            scope: "user-read-currently-playing",
+            show_dialog: "true",
+            state: "secure-state",
+        });
+    });
+
+    it("accepts a callback only when state and authorization code are present", () => {
+        const url = new URL(
+            "http://127.0.0.1:8888/callback?code=authorization-code&state=expected-state"
+        );
+
+        expect(validateCallbackParameters(url, "expected-state")).toBe("authorization-code");
+    });
+
+    it.each([
+        ["?code=authorization-code&state=wrong", "OAuth state mismatch"],
+        ["?error=access_denied&state=expected", "access_denied"],
+        ["?state=expected", "did not include a code"],
+    ])("rejects an invalid callback %s", (query, expectedMessage) => {
+        const url = new URL(`http://127.0.0.1:8888/callback${query}`);
+
+        expect(() => validateCallbackParameters(url, "expected")).toThrow(expectedMessage);
+    });
+
+    it("exchanges the code using Basic authentication and the exact callback URI", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    access_token: "access-token",
+                    refresh_token: "refresh-token",
+                }),
+                { headers: { "Content-Type": "application/json" }, status: 200 }
+            )
+        );
+
+        await expect(
+            exchangeAuthorizationCode({
+                clientId: "client-id",
+                clientSecret: "client-secret",
+                code: "authorization-code",
+                fetchImpl: fetchMock,
+            })
+        ).resolves.toEqual({ accessToken: "access-token", refreshToken: "refresh-token" });
+
+        const firstCall = fetchMock.mock.calls.at(0);
+        if (!firstCall) throw new Error("Expected Spotify token request");
+        const [, request] = firstCall;
+        expect(request?.headers).toMatchObject({
+            Authorization: `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+        });
+        expect(request?.body?.toString()).toBe(
+            "code=authorization-code&grant_type=authorization_code&redirect_uri=http%3A%2F%2F127.0.0.1%3A8888%2Fcallback"
+        );
+    });
+
+    it("rejects a failed or malformed token exchange", async () => {
+        const failedFetch = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify({ error: "invalid_grant" }), {
+                headers: { "Content-Type": "application/json" },
+                status: 400,
+            })
+        );
+        const malformedFetch = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify({ access_token: "access-token" }), {
+                headers: { "Content-Type": "application/json" },
+                status: 200,
+            })
+        );
+
+        await expect(
+            exchangeAuthorizationCode({
+                clientId: "client-id",
+                clientSecret: "client-secret",
+                code: "code",
+                fetchImpl: failedFetch,
+            })
+        ).rejects.toThrow("invalid_grant");
+        await expect(
+            exchangeAuthorizationCode({
+                clientId: "client-id",
+                clientSecret: "client-secret",
+                code: "code",
+                fetchImpl: malformedFetch,
+            })
+        ).rejects.toThrow("invalid response");
+    });
+
+    it.each([200, 204])("accepts Spotify playback verification status %i", async (status) => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status }));
+
+        await expect(verifyAccessToken("access-token", fetchMock)).resolves.toBeUndefined();
+        expect(fetchMock).toHaveBeenCalledWith(
+            "https://api.spotify.com/v1/me/player/currently-playing",
+            { headers: { Authorization: "Bearer access-token" } }
+        );
+    });
+
+    it("upserts the refresh token without changing other environment values", () => {
+        expect(
+            upsertEnvValue(
+                'SPOTIFY_CLIENT_ID="client-id"\nSPOTIFY_REFRESH_TOKEN="old"\nOTHER="value"\n',
+                "SPOTIFY_REFRESH_TOKEN",
+                "new-token"
+            )
+        ).toBe('SPOTIFY_CLIENT_ID="client-id"\nSPOTIFY_REFRESH_TOKEN="new-token"\nOTHER="value"\n');
+        expect(
+            upsertEnvValue('SPOTIFY_CLIENT_ID="client-id"', "SPOTIFY_REFRESH_TOKEN", "new")
+        ).toBe('SPOTIFY_CLIENT_ID="client-id"\nSPOTIFY_REFRESH_TOKEN="new"\n');
+    });
+
+    it("publishes the refresh token through stdin instead of command arguments", async () => {
+        const runCommand = vi.fn().mockResolvedValue(undefined);
+
+        await publishRefreshToken("sensitive-refresh-token", runCommand);
+
+        expect(runCommand).toHaveBeenCalledWith(
+            ["secret", "put", "SPOTIFY_REFRESH_TOKEN"],
+            "sensitive-refresh-token"
+        );
+        const firstCall = runCommand.mock.calls.at(0);
+        if (!firstCall) throw new Error("Expected Wrangler invocation");
+        expect(JSON.stringify(firstCall[0])).not.toContain("sensitive-refresh-token");
+    });
+});

--- a/scripts/spotify-authorize.mjs
+++ b/scripts/spotify-authorize.mjs
@@ -1,0 +1,265 @@
+import { randomBytes } from "node:crypto";
+import { readFile, rename, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const AUTHORIZE_ENDPOINT = "https://accounts.spotify.com/authorize";
+const TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token";
+const NOW_PLAYING_ENDPOINT = "https://api.spotify.com/v1/me/player/currently-playing";
+const REDIRECT_URI = "http://127.0.0.1:8888/callback";
+const CALLBACK_TIMEOUT_MS = 10 * 60 * 1000;
+const ENV_KEY = "SPOTIFY_REFRESH_TOKEN";
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = join(SCRIPT_DIRECTORY, "..");
+
+export const buildAuthorizationUrl = ({ clientId, state }) => {
+    const url = new URL(AUTHORIZE_ENDPOINT);
+    url.search = new URLSearchParams({
+        client_id: clientId,
+        redirect_uri: REDIRECT_URI,
+        response_type: "code",
+        scope: "user-read-currently-playing",
+        show_dialog: "true",
+        state,
+    }).toString();
+    return url;
+};
+
+export const validateCallbackParameters = (url, expectedState) => {
+    const error = url.searchParams.get("error");
+    if (error) throw new Error(`Spotify authorization failed: ${error}`);
+
+    const state = url.searchParams.get("state");
+    if (!state || state !== expectedState) {
+        throw new Error("Spotify authorization failed: OAuth state mismatch");
+    }
+
+    const code = url.searchParams.get("code");
+    if (!code) throw new Error("Spotify authorization failed: callback did not include a code");
+    return code;
+};
+
+export const exchangeAuthorizationCode = async ({
+    clientId,
+    clientSecret,
+    code,
+    fetchImpl = fetch,
+}) => {
+    const authorization = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+    const response = await fetchImpl(TOKEN_ENDPOINT, {
+        method: "POST",
+        headers: {
+            Authorization: `Basic ${authorization}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+            code,
+            grant_type: "authorization_code",
+            redirect_uri: REDIRECT_URI,
+        }),
+    });
+
+    let body = {};
+    try {
+        body = await response.json();
+    } catch {
+        // The validation below produces the actionable error.
+    }
+
+    if (!response.ok) {
+        const error = typeof body.error === "string" ? body.error : "unknown_error";
+        throw new Error(`Spotify token exchange failed (${response.status}): ${error}`);
+    }
+    if (typeof body.access_token !== "string" || typeof body.refresh_token !== "string") {
+        throw new Error("Spotify token exchange returned an invalid response");
+    }
+
+    return {
+        accessToken: body.access_token,
+        refreshToken: body.refresh_token,
+    };
+};
+
+export const verifyAccessToken = async (accessToken, fetchImpl = fetch) => {
+    const response = await fetchImpl(NOW_PLAYING_ENDPOINT, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (response.status !== 200 && response.status !== 204) {
+        throw new Error(`Spotify access-token verification failed (${response.status})`);
+    }
+};
+
+export const upsertEnvValue = (contents, key, value) => {
+    const line = `${key}=${JSON.stringify(value)}`;
+    const pattern = new RegExp(`^${key}=.*$`, "m");
+    if (pattern.test(contents)) return contents.replace(pattern, line);
+    return `${contents}${contents && !contents.endsWith("\n") ? "\n" : ""}${line}\n`;
+};
+
+export const publishRefreshToken = async (refreshToken, runCommand) => {
+    const execute = runCommand ?? runWranglerSecretPut;
+    await execute(["secret", "put", ENV_KEY], refreshToken);
+};
+
+const runWranglerSecretPut = (args, input) =>
+    new Promise((resolve, reject) => {
+        const executable = join(
+            REPOSITORY_ROOT,
+            "node_modules",
+            ".bin",
+            process.platform === "win32" ? "wrangler.cmd" : "wrangler"
+        );
+        const child = spawn(executable, args, {
+            cwd: REPOSITORY_ROOT,
+            shell: false,
+            stdio: ["pipe", "inherit", "inherit"],
+        });
+        child.once("error", reject);
+        child.once("exit", (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`Wrangler exited with code ${code ?? "unknown"}`));
+        });
+        child.stdin.end(input);
+    });
+
+const writeLocalRefreshToken = async (refreshToken) => {
+    const envPath = join(REPOSITORY_ROOT, ".env");
+    let contents = "";
+    try {
+        contents = await readFile(envPath, "utf8");
+    } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+    }
+
+    const temporaryPath = `${envPath}.tmp-${process.pid}`;
+    await writeFile(temporaryPath, upsertEnvValue(contents, ENV_KEY, refreshToken), {
+        encoding: "utf8",
+        mode: 0o600,
+    });
+    await rename(temporaryPath, envPath);
+};
+
+const openBrowser = (url) => {
+    const commands = {
+        darwin: ["open", [url]],
+        linux: ["xdg-open", [url]],
+        win32: ["cmd", ["/c", "start", "", url]],
+    };
+    const command = commands[process.platform];
+    if (!command) return;
+
+    try {
+        const child = spawn(command[0], command[1], {
+            detached: true,
+            stdio: "ignore",
+        });
+        child.once("error", () => undefined);
+        child.unref();
+    } catch {
+        // The URL is always printed, so browser launch is only a convenience.
+    }
+};
+
+const waitForAuthorizationCode = (expectedState) =>
+    new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = (callback) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            server.close();
+            callback();
+        };
+        const server = createServer((request, response) => {
+            const url = new URL(request.url ?? "/", REDIRECT_URI);
+            if (url.pathname !== "/callback") {
+                response.writeHead(404).end("Not found");
+                return;
+            }
+
+            try {
+                const code = validateCallbackParameters(url, expectedState);
+                response.writeHead(200, {
+                    "Cache-Control": "no-store",
+                    "Content-Type": "text/plain; charset=utf-8",
+                });
+                response.end("Spotify authorization received. You can return to the terminal.");
+                finish(() => resolve(code));
+            } catch (error) {
+                response.writeHead(400, {
+                    "Cache-Control": "no-store",
+                    "Content-Type": "text/plain; charset=utf-8",
+                });
+                response.end("Spotify authorization failed. Return to the terminal for details.");
+                finish(() => reject(error));
+            }
+        });
+        const timeout = setTimeout(() => {
+            finish(() => reject(new Error("Spotify authorization timed out after 10 minutes")));
+        }, CALLBACK_TIMEOUT_MS);
+        server.once("error", (error) => finish(() => reject(error)));
+        server.listen(8888, "127.0.0.1");
+    });
+
+const parseArguments = (arguments_) => {
+    const localOnly = arguments_.includes("--local-only");
+    const publishOnly = arguments_.includes("--publish-only");
+    const unknown = arguments_.filter(
+        (argument) => argument !== "--local-only" && argument !== "--publish-only"
+    );
+    if (unknown.length > 0 || (localOnly && publishOnly)) {
+        throw new Error("Usage: npm run spotify:authorize -- [--local-only | --publish-only]");
+    }
+    return { localOnly, publishOnly };
+};
+
+export const main = async () => {
+    const { localOnly, publishOnly } = parseArguments(process.argv.slice(2));
+
+    if (publishOnly) {
+        if (!process.env.SPOTIFY_REFRESH_TOKEN) {
+            throw new Error("SPOTIFY_REFRESH_TOKEN is missing from .env");
+        }
+        await publishRefreshToken(process.env.SPOTIFY_REFRESH_TOKEN);
+        console.log("Published the local Spotify refresh token to Cloudflare.");
+        return;
+    }
+
+    const clientId = process.env.SPOTIFY_CLIENT_ID;
+    const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+        throw new Error("SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET are required in .env");
+    }
+
+    const state = randomBytes(32).toString("hex");
+    const authorizationCode = waitForAuthorizationCode(state);
+    const authorizationUrl = buildAuthorizationUrl({ clientId, state }).toString();
+    console.log(`Open this URL to authorize Spotify:\n${authorizationUrl}`);
+    openBrowser(authorizationUrl);
+
+    const code = await authorizationCode;
+    const tokens = await exchangeAuthorizationCode({ clientId, clientSecret, code });
+    await verifyAccessToken(tokens.accessToken);
+    await writeLocalRefreshToken(tokens.refreshToken);
+    console.log("Saved the new Spotify refresh token to .env.");
+
+    if (!localOnly) {
+        try {
+            await publishRefreshToken(tokens.refreshToken);
+            console.log("Published the new Spotify refresh token to Cloudflare.");
+        } catch (error) {
+            console.error("Cloudflare publication failed; the new token is safe in .env.");
+            console.error("Retry with: npm run spotify:authorize -- --publish-only");
+            throw error;
+        }
+    }
+};
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+    main().catch((error) => {
+        console.error(error instanceof Error ? error.message : "Spotify authorization failed");
+        process.exitCode = 1;
+    });
+}

--- a/src/lib/__tests__/spotify.test.ts
+++ b/src/lib/__tests__/spotify.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const credentials = {
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    refreshToken: "refresh-token",
+};
+
+const emptyResponse = {
+    album: "",
+    albumImageUrl: "",
+    artist: "",
+    isPlaying: false,
+    songUrl: "",
+    title: "",
+};
+
+class MemoryKv {
+    readonly values = new Map<string, string>();
+    readonly puts: Array<{ key: string; value: string }> = [];
+    readonly deletes: string[] = [];
+
+    async get(key: string, type: "json"): Promise<unknown | null> {
+        expect(type).toBe("json");
+        const value = this.values.get(key);
+        return value ? JSON.parse(value) : null;
+    }
+
+    async put(key: string, value: string): Promise<void> {
+        this.puts.push({ key, value });
+        this.values.set(key, value);
+    }
+
+    async delete(key: string): Promise<void> {
+        this.deletes.push(key);
+        this.values.delete(key);
+    }
+}
+
+const tokenResponse = (accessToken = "access-token") =>
+    new Response(JSON.stringify({ access_token: accessToken, expires_in: 3600 }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+    });
+
+const noPlaybackResponse = () => new Response(null, { status: 204 });
+
+const loadSpotify = async () => import("../spotify");
+
+describe("Spotify token refresh", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("refreshes once and reuses the cached access token", async () => {
+        const fetchMock = vi
+            .fn<typeof fetch>()
+            .mockResolvedValueOnce(tokenResponse())
+            .mockResolvedValueOnce(noPlaybackResponse())
+            .mockResolvedValueOnce(noPlaybackResponse());
+        vi.stubGlobal("fetch", fetchMock);
+        const { getNowPlaying } = await loadSpotify();
+
+        expect(await getNowPlaying(credentials)).toEqual(emptyResponse);
+        expect(await getNowPlaying(credentials)).toEqual(emptyResponse);
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(
+            fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/token"))
+        ).toHaveLength(1);
+    });
+
+    it("deduplicates concurrent access-token refreshes", async () => {
+        let resolveTokenResponse: ((response: Response) => void) | undefined;
+        const pendingTokenResponse = new Promise<Response>((resolve) => {
+            resolveTokenResponse = resolve;
+        });
+        const fetchMock = vi.fn<typeof fetch>((url) => {
+            if (String(url).includes("/api/token")) return pendingTokenResponse;
+            return Promise.resolve(noPlaybackResponse());
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        const { getNowPlaying } = await loadSpotify();
+
+        const firstRequest = getNowPlaying(credentials);
+        const secondRequest = getNowPlaying(credentials);
+        await vi.waitFor(() => {
+            expect(
+                fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/token"))
+            ).toHaveLength(1);
+        });
+        resolveTokenResponse?.(tokenResponse());
+
+        expect(await Promise.all([firstRequest, secondRequest])).toEqual([
+            emptyResponse,
+            emptyResponse,
+        ]);
+        expect(
+            fetchMock.mock.calls.filter(([url]) => String(url).includes("/api/token"))
+        ).toHaveLength(1);
+    });
+
+    it("persists invalid_grant without the token and never retries it", async () => {
+        const kv = new MemoryKv();
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify({ error: "invalid_grant" }), {
+                headers: { "Content-Type": "application/json" },
+                status: 400,
+            })
+        );
+        vi.stubGlobal("fetch", fetchMock);
+        let spotify = await loadSpotify();
+
+        expect(await spotify.getNowPlaying(credentials, kv)).toEqual(emptyResponse);
+        expect(await spotify.getNowPlaying(credentials, kv)).toEqual(emptyResponse);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const marker = kv.values.get("spotify:invalid-refresh-token");
+        expect(marker).toBeDefined();
+        expect(marker).not.toContain(credentials.refreshToken);
+        expect(JSON.parse(marker ?? "{}")).toMatchObject({
+            fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+        });
+        expect(console.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                action: "npm run spotify:authorize",
+                event: "spotify_reauthorization_required",
+            })
+        );
+
+        vi.resetModules();
+        spotify = await loadSpotify();
+        expect(await spotify.getNowPlaying(credentials, kv)).toEqual(emptyResponse);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows a replacement refresh token and removes the stale marker", async () => {
+        const kv = new MemoryKv();
+        const invalidGrant = new Response(JSON.stringify({ error: "invalid_grant" }), {
+            headers: { "Content-Type": "application/json" },
+            status: 400,
+        });
+        const fetchMock = vi
+            .fn<typeof fetch>()
+            .mockResolvedValueOnce(invalidGrant)
+            .mockResolvedValueOnce(tokenResponse("replacement-access-token"))
+            .mockResolvedValueOnce(noPlaybackResponse());
+        vi.stubGlobal("fetch", fetchMock);
+        const { getNowPlaying } = await loadSpotify();
+
+        await getNowPlaying(credentials, kv);
+        const replacementCredentials = { ...credentials, refreshToken: "replacement-token" };
+        expect(await getNowPlaying(replacementCredentials, kv)).toEqual(emptyResponse);
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(kv.deletes).toContain("spotify:invalid-refresh-token");
+        expect(kv.values.has("spotify:invalid-refresh-token")).toBe(false);
+    });
+
+    it("keeps transient refresh failures retryable", async () => {
+        const kv = new MemoryKv();
+        const fetchMock = vi.fn<typeof fetch>().mockImplementation(() =>
+            Promise.resolve(
+                new Response(JSON.stringify({ error: "temporarily_unavailable" }), {
+                    headers: { "Content-Type": "application/json" },
+                    status: 503,
+                })
+            )
+        );
+        vi.stubGlobal("fetch", fetchMock);
+        const { getNowPlaying } = await loadSpotify();
+
+        expect(await getNowPlaying(credentials, kv)).toEqual(emptyResponse);
+        expect(await getNowPlaying(credentials, kv)).toEqual(emptyResponse);
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(kv.values.has("spotify:invalid-refresh-token")).toBe(false);
+        expect(console.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: "temporarily_unavailable",
+                event: "spotify_token_refresh_failed",
+            })
+        );
+    });
+
+    it("returns the empty state for a malformed successful token response", async () => {
+        const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(JSON.stringify({ expires_in: 3600 }), {
+                headers: { "Content-Type": "application/json" },
+                status: 200,
+            })
+        );
+        vi.stubGlobal("fetch", fetchMock);
+        const { getNowPlaying } = await loadSpotify();
+
+        expect(await getNowPlaying(credentials)).toEqual(emptyResponse);
+        expect(console.error).toHaveBeenCalledWith(
+            expect.objectContaining({ event: "spotify_token_response_invalid" })
+        );
+    });
+
+    it("maps a currently playing track and caches it in KV", async () => {
+        const kv = new MemoryKv();
+        const fetchMock = vi
+            .fn<typeof fetch>()
+            .mockResolvedValueOnce(tokenResponse())
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        is_playing: true,
+                        item: {
+                            album: {
+                                images: [{ url: "https://image.example/cover.jpg" }],
+                                name: "Album",
+                            },
+                            artists: [{ name: "First" }, { name: "Second" }],
+                            external_urls: { spotify: "https://open.spotify.com/track/123" },
+                            name: "Song",
+                        },
+                    }),
+                    { headers: { "Content-Type": "application/json" }, status: 200 }
+                )
+            );
+        vi.stubGlobal("fetch", fetchMock);
+        const { getNowPlaying } = await loadSpotify();
+
+        expect(await getNowPlaying(credentials, kv)).toEqual({
+            album: "Album",
+            albumImageUrl: "https://image.example/cover.jpg",
+            artist: "First, Second",
+            isPlaying: true,
+            songUrl: "https://open.spotify.com/track/123",
+            title: "Song",
+        });
+        expect(JSON.parse(kv.values.get("spotify:now-playing") ?? "{}")).toMatchObject({
+            isPlaying: true,
+            title: "Song",
+        });
+    });
+});

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,16 +1,18 @@
 const NOW_PLAYING_ENDPOINT = "https://api.spotify.com/v1/me/player/currently-playing";
 const TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token";
+const NOW_PLAYING_CACHE_KEY = "spotify:now-playing";
+const INVALID_REFRESH_TOKEN_KEY = "spotify:invalid-refresh-token";
+const NOW_PLAYING_TTL_MS = 30_000;
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 60_000;
 
 let cachedAccessToken: string | null = null;
+let cachedAccessTokenFingerprint: string | null = null;
 let tokenExpiryTime: number | null = null;
-
 let cachedNowPlaying: NowPlayingSong | null = null;
 let nowPlayingCacheExpiry: number | null = null;
-const NOW_PLAYING_TTL_MS = 30_000;
-const KV_TIMEOUT_MS = 500;
 
-const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T | null> =>
-    Promise.race([promise, new Promise<null>((resolve) => setTimeout(() => resolve(null), ms))]);
+const rejectedRefreshTokenFingerprints = new Set<string>();
+const refreshesInFlight = new Map<string, Promise<string | null>>();
 
 interface SpotifyCredentials {
     clientId: string;
@@ -18,15 +20,110 @@ interface SpotifyCredentials {
     refreshToken: string;
 }
 
-const getAccessToken = async (credentials: SpotifyCredentials): Promise<string | null> => {
-    const currentTime = Date.now();
+interface SpotifyKvStore {
+    get(key: string, type: "json"): Promise<unknown | null>;
+    put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+    delete(key: string): Promise<void>;
+}
 
-    if (cachedAccessToken && tokenExpiryTime && currentTime < tokenExpiryTime) {
-        return cachedAccessToken;
+interface InvalidRefreshTokenMarker {
+    detectedAt: string;
+    fingerprint: string;
+}
+
+interface SpotifyTokenResponse {
+    access_token?: unknown;
+    error?: unknown;
+    expires_in?: unknown;
+}
+
+const fingerprintRefreshToken = async (refreshToken: string): Promise<string> => {
+    const input = new TextEncoder().encode(refreshToken);
+    const digest = await crypto.subtle.digest("SHA-256", input);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(
+        ""
+    );
+};
+
+const isInvalidRefreshTokenMarker = (value: unknown): value is InvalidRefreshTokenMarker => {
+    if (!value || typeof value !== "object") return false;
+    const marker = value as Record<string, unknown>;
+    return typeof marker.detectedAt === "string" && typeof marker.fingerprint === "string";
+};
+
+const parseTokenResponse = async (response: Response): Promise<SpotifyTokenResponse> => {
+    try {
+        const value: unknown = await response.json();
+        return value && typeof value === "object" ? (value as SpotifyTokenResponse) : {};
+    } catch {
+        return {};
+    }
+};
+
+const clearSpotifyCaches = (): void => {
+    cachedAccessToken = null;
+    cachedAccessTokenFingerprint = null;
+    tokenExpiryTime = null;
+    cachedNowPlaying = null;
+    nowPlayingCacheExpiry = null;
+};
+
+const persistInvalidRefreshToken = async (
+    kv: SpotifyKvStore | undefined,
+    fingerprint: string
+): Promise<void> => {
+    rejectedRefreshTokenFingerprints.add(fingerprint);
+    clearSpotifyCaches();
+
+    if (!kv) return;
+
+    const marker: InvalidRefreshTokenMarker = {
+        detectedAt: new Date().toISOString(),
+        fingerprint,
+    };
+
+    const results = await Promise.allSettled([
+        kv.put(INVALID_REFRESH_TOKEN_KEY, JSON.stringify(marker)),
+        kv.delete(NOW_PLAYING_CACHE_KEY),
+    ]);
+
+    if (results.some((result) => result.status === "rejected")) {
+        console.error({
+            event: "spotify_token_invalidation_persistence_failed",
+        });
+    }
+};
+
+const isRefreshTokenRejected = async (
+    kv: SpotifyKvStore | undefined,
+    fingerprint: string
+): Promise<boolean> => {
+    if (rejectedRefreshTokenFingerprints.has(fingerprint)) return true;
+    if (!kv) return false;
+
+    try {
+        const value = await kv.get(INVALID_REFRESH_TOKEN_KEY, "json");
+        if (isInvalidRefreshTokenMarker(value) && value.fingerprint === fingerprint) {
+            rejectedRefreshTokenFingerprints.add(fingerprint);
+            return true;
+        }
+    } catch {
+        console.error({
+            event: "spotify_token_invalidation_lookup_failed",
+        });
     }
 
-    const basic = btoa(`${credentials.clientId}:${credentials.clientSecret}`);
+    return false;
+};
 
+const refreshAccessToken = async (
+    credentials: SpotifyCredentials,
+    kv: SpotifyKvStore | undefined,
+    fingerprint: string
+): Promise<string | null> => {
+    if (await isRefreshTokenRejected(kv, fingerprint)) return null;
+
+    const basic = btoa(`${credentials.clientId}:${credentials.clientSecret}`);
     const response = await fetch(TOKEN_ENDPOINT, {
         method: "POST",
         headers: {
@@ -38,18 +135,85 @@ const getAccessToken = async (credentials: SpotifyCredentials): Promise<string |
             refresh_token: credentials.refreshToken,
         }),
     });
+    const data = await parseTokenResponse(response);
 
     if (!response.ok) {
-        console.error(`Failed to fetch access token: ${response.statusText}`);
+        if (data.error === "invalid_grant") {
+            await persistInvalidRefreshToken(kv, fingerprint);
+            console.error({
+                action: "npm run spotify:authorize",
+                event: "spotify_reauthorization_required",
+                status: response.status,
+            });
+            return null;
+        }
+
+        console.error({
+            error: typeof data.error === "string" ? data.error : "unknown_error",
+            event: "spotify_token_refresh_failed",
+            status: response.status,
+        });
         return null;
     }
 
-    const data = await response.json();
+    if (
+        typeof data.access_token !== "string" ||
+        typeof data.expires_in !== "number" ||
+        !Number.isFinite(data.expires_in) ||
+        data.expires_in <= 0
+    ) {
+        console.error({
+            event: "spotify_token_response_invalid",
+            status: response.status,
+        });
+        return null;
+    }
 
     cachedAccessToken = data.access_token;
-    tokenExpiryTime = currentTime + data.expires_in * 1000;
+    cachedAccessTokenFingerprint = fingerprint;
+    tokenExpiryTime =
+        Date.now() + Math.max(0, data.expires_in * 1000 - ACCESS_TOKEN_EXPIRY_BUFFER_MS);
+
+    if (kv) {
+        try {
+            const marker = await kv.get(INVALID_REFRESH_TOKEN_KEY, "json");
+            if (isInvalidRefreshTokenMarker(marker) && marker.fingerprint !== fingerprint) {
+                await kv.delete(INVALID_REFRESH_TOKEN_KEY);
+            }
+        } catch {
+            console.error({
+                event: "spotify_stale_invalidation_cleanup_failed",
+            });
+        }
+    }
 
     return cachedAccessToken;
+};
+
+const getAccessToken = async (
+    credentials: SpotifyCredentials,
+    kv?: SpotifyKvStore
+): Promise<string | null> => {
+    const fingerprint = await fingerprintRefreshToken(credentials.refreshToken);
+    const currentTime = Date.now();
+
+    if (
+        cachedAccessToken &&
+        cachedAccessTokenFingerprint === fingerprint &&
+        tokenExpiryTime &&
+        currentTime < tokenExpiryTime
+    ) {
+        return cachedAccessToken;
+    }
+
+    const existingRefresh = refreshesInFlight.get(fingerprint);
+    if (existingRefresh) return existingRefresh;
+
+    const refresh = refreshAccessToken(credentials, kv, fingerprint).finally(() => {
+        refreshesInFlight.delete(fingerprint);
+    });
+    refreshesInFlight.set(fingerprint, refresh);
+    return refresh;
 };
 
 export interface NowPlayingSong {
@@ -70,9 +234,22 @@ const EMPTY_RESPONSE: NowPlayingSong = {
     title: "",
 };
 
+const isNowPlayingSong = (value: unknown): value is NowPlayingSong => {
+    if (!value || typeof value !== "object") return false;
+    const song = value as Record<string, unknown>;
+    return (
+        typeof song.album === "string" &&
+        typeof song.albumImageUrl === "string" &&
+        typeof song.artist === "string" &&
+        typeof song.isPlaying === "boolean" &&
+        typeof song.songUrl === "string" &&
+        typeof song.title === "string"
+    );
+};
+
 export const getNowPlaying = async (
     credentials: SpotifyCredentials,
-    kv?: KVNamespace
+    kv?: SpotifyKvStore
 ): Promise<NowPlayingSong> => {
     const currentTime = Date.now();
 
@@ -82,26 +259,20 @@ export const getNowPlaying = async (
 
     if (kv) {
         try {
-            const kvCached = await withTimeout(
-                kv.get<NowPlayingSong>("spotify:now-playing", "json"),
-                KV_TIMEOUT_MS
-            );
-            if (kvCached) {
+            const kvCached = await kv.get(NOW_PLAYING_CACHE_KEY, "json");
+            if (isNowPlayingSong(kvCached)) {
                 cachedNowPlaying = kvCached;
                 nowPlayingCacheExpiry = currentTime + NOW_PLAYING_TTL_MS;
                 return kvCached;
             }
         } catch {
-            // KV read failed, fall through to API
+            // KV read failed, fall through to Spotify.
         }
     }
 
     try {
-        const accessToken = await getAccessToken(credentials);
-
-        if (!accessToken) {
-            return EMPTY_RESPONSE;
-        }
+        const accessToken = await getAccessToken(credentials, kv);
+        if (!accessToken) return EMPTY_RESPONSE;
 
         const response = await fetch(NOW_PLAYING_ENDPOINT, {
             headers: {
@@ -110,20 +281,29 @@ export const getNowPlaying = async (
             cache: "no-store",
         });
 
-        if (response.status === 204 || response.status >= 400) {
+        if (response.status === 204 || response.status >= 400) return EMPTY_RESPONSE;
+
+        const song: unknown = await response.json();
+        if (!song || typeof song !== "object" || !("item" in song) || !song.item) {
             return EMPTY_RESPONSE;
         }
 
-        const song = await response.json();
-        if (!song?.item) return EMPTY_RESPONSE;
-
+        const spotifySong = song as {
+            is_playing?: boolean;
+            item: {
+                album?: { images?: Array<{ url?: string }>; name?: string };
+                artists?: Array<{ name: string }>;
+                external_urls?: { spotify?: string };
+                name?: string;
+            };
+        };
         const result: NowPlayingSong = {
-            album: song.item.album?.name ?? "",
-            albumImageUrl: song.item.album?.images?.[0]?.url ?? "",
-            artist: song.item.artists?.map((a: { name: string }) => a.name).join(", ") ?? "",
-            isPlaying: song.is_playing ?? false,
-            songUrl: song.item.external_urls?.spotify ?? "",
-            title: song.item.name ?? "",
+            album: spotifySong.item.album?.name ?? "",
+            albumImageUrl: spotifySong.item.album?.images?.[0]?.url ?? "",
+            artist: spotifySong.item.artists?.map((artist) => artist.name).join(", ") ?? "",
+            isPlaying: spotifySong.is_playing ?? false,
+            songUrl: spotifySong.item.external_urls?.spotify ?? "",
+            title: spotifySong.item.name ?? "",
         };
 
         cachedNowPlaying = result;
@@ -131,18 +311,18 @@ export const getNowPlaying = async (
 
         if (kv) {
             try {
-                await withTimeout(
-                    kv.put("spotify:now-playing", JSON.stringify(result), { expirationTtl: 30 }),
-                    KV_TIMEOUT_MS
-                );
+                await kv.put(NOW_PLAYING_CACHE_KEY, JSON.stringify(result), { expirationTtl: 30 });
             } catch {
-                // KV write failed, not critical
+                // KV caching is best effort.
             }
         }
 
         return result;
     } catch (error) {
-        console.error("Error fetching now playing data:", error);
+        console.error({
+            error: error instanceof Error ? error.message : "unknown_error",
+            event: "spotify_now_playing_failed",
+        });
         return EMPTY_RESPONSE;
     }
 };


### PR DESCRIPTION
## Summary
- stop retrying Spotify refresh tokens after an `invalid_grant` response
- persist only a token fingerprint in KV and keep the public footer fallback unchanged
- add a local owner-only reauthorization command that updates the Cloudflare secret through Wrangler
- document the six-month reauthorization workflow

## Testing
- `npm run test` (26 tests passed)
- `npm run lint`
- `npm run build`
- Prettier check